### PR TITLE
Validate output of pico-env.cmd before setting env. variables

### DIFF
--- a/packages/pico-setup-windows/pico-env.ps1
+++ b/packages/pico-setup-windows/pico-env.ps1
@@ -5,7 +5,11 @@ $ProgressPreference = 'SilentlyContinue'
 # https://github.com/microsoft/vswhere/wiki/Start-Developer-Command-Prompt#using-powershell
 & "${env:COMSPEC}" /s /c "`"$PSScriptRoot\pico-env.cmd`" && set" | ForEach-Object {
   $name, $value = $_ -split '=', 2
-  Set-Content env:\"$name" $value
+  
+  # Check if the split produced a valid name and value, to ignore informative messages and empty lines
+  if (-not [string]::IsNullOrEmpty($name) -and -not [string]::IsNullOrEmpty($value)) {
+    Set-Content env:\"$name" $value
+  }
 }
 
 Get-ChildItem env:PICO_*, env:OPENOCD_* | ForEach-Object { '{0}={1}' -f $_.Name, $_.Value }


### PR DESCRIPTION
Check if the split produced a valid name and value, to ignore informative messages and empty lines (Bugfix for issue #50)